### PR TITLE
Toggle topbar when logout widget is opened/closed

### DIFF
--- a/etc/skel/.config/qtile/config.py
+++ b/etc/skel/.config/qtile/config.py
@@ -30,7 +30,7 @@ import re
 import socket
 import subprocess
 from typing import List  # noqa: F401
-from libqtile import layout, bar, widget, hook
+from libqtile import layout, bar, widget, hook, qtile
 from libqtile.config import Click, Drag, Group, Key, Match, Screen, Rule
 from libqtile.command import lazy
 from libqtile.widget import Spacer
@@ -532,9 +532,19 @@ dgroups_app_rules = []
 # END
 # ASSIGN APPLICATIONS TO A SPECIFIC GROUPNAME
 
-
-
 main = None
+
+# hides the top bar when the archlinux-logout widget is opened
+@hook.subscribe.client_new
+def new_client(window):
+    if window.name == "ArchLinux Logout":
+        qtile.hide_show_bar()
+
+# shows the top bar when the archlinux-logout widget is closed
+@hook.subscribe.client_killed
+def logout_killed(window):
+    if window.name == "ArchLinux Logout":
+        qtile.hide_show_bar()
 
 @hook.subscribe.startup_once
 def start_once():
@@ -580,7 +590,8 @@ floating_layout = layout.Floating(float_rules=[
     Match(wm_class='Arandr'),
     Match(wm_class='feh'),
     Match(wm_class='Galculator'),
-    Match(wm_class='archlinux-logout'),
+    Match(wm_class='archlinux-logout.py'),
+    Match(wm_class='Archlinux-logout.py'),
     Match(wm_class='xfce4-terminal'),
 
 ],  fullscreen_border_width = 0, border_width = 0)


### PR DESCRIPTION
This patch ensures the topbar in Qtile is hidden when the archlinux-logout widget is opened.
![Screenshot_20231023_160844](https://github.com/arcolinux/arcolinux-qtile/assets/121581829/5ec377bc-6911-470b-a0fc-c68a16a719b2)

The topbar becomes visible when the widget is closed.
![Screenshot_20231023_160919](https://github.com/arcolinux/arcolinux-qtile/assets/121581829/e0aa1dc5-ff96-4072-876d-89edc3639a8e)
