### PR TITLE
Qtile Lazy

### DIFF
--- a/etc/skel/.config/qtile/config-azerty.py
+++ b/etc/skel/.config/qtile/config-azerty.py
@@ -32,7 +32,7 @@ import subprocess
 from typing import List  # noqa: F401
 from libqtile import layout, bar, widget, hook, qtile
 from libqtile.config import Click, Drag, Group, Key, Match, Screen, Rule
-from libqtile.command import lazy
+from libqtile.lazy import lazy
 from libqtile.widget import Spacer
 #import arcobattery
 

--- a/etc/skel/.config/qtile/config-qwerty.py
+++ b/etc/skel/.config/qtile/config-qwerty.py
@@ -32,7 +32,7 @@ import subprocess
 from typing import List  # noqa: F401
 from libqtile import layout, bar, widget, hook, qtile
 from libqtile.config import Click, Drag, Group, Key, Match, Screen, Rule
-from libqtile.command import lazy
+from libqtile.lazy import lazy
 from libqtile.widget import Spacer
 #import arcobattery
 

--- a/etc/skel/.config/qtile/config.py
+++ b/etc/skel/.config/qtile/config.py
@@ -32,7 +32,7 @@ import subprocess
 from typing import List  # noqa: F401
 from libqtile import layout, bar, widget, hook, qtile
 from libqtile.config import Click, Drag, Group, Key, Match, Screen, Rule
-from libqtile.command import lazy
+from libqtile.lazy import lazy
 from libqtile.widget import Spacer
 #import arcobattery
 


### PR DESCRIPTION
`lazy` is not in `libqtile.command `anymore. This error results in the whole config crashing.